### PR TITLE
Media queries for BG images and using standard WP image functions.

### DIFF
--- a/wp-content/themes/amavi2017/buildable.php
+++ b/wp-content/themes/amavi2017/buildable.php
@@ -6,9 +6,9 @@ if( have_rows('single_blocks') ):
 	// loop through the rows of data
 	while ( have_rows('single_blocks') ) : the_row();
 
-		if( get_row_layout() == 'wide_image' ): 
+		if( get_row_layout() == 'wide_image' ):
 
-			$image = get_sub_field( 'wide_image_field' ); 
+			$image = get_sub_field( 'wide_image_field' );
 
 			if ( $image ) { ?>
 
@@ -16,7 +16,7 @@ if( have_rows('single_blocks') ):
 
 					<div class="picture-wide col-s-12">
 
-						<img src="<?php echo $image['url']; ?>" class="picture-wide__image" alt="<?php echo $image['alt']; ?>" />
+						<?php echo wp_get_attachment_image( $image['ID'], 'fullsize', false, array( 'class' => 'picture-wide__image' ) ); ?>
 
 					</div>
 
@@ -25,17 +25,17 @@ if( have_rows('single_blocks') ):
 			<?php
 			} ; // End if $image
 
-		elseif( get_row_layout() == 'content' ): 
+		elseif( get_row_layout() == 'content' ):
 
-			$content = get_sub_field( 'content_field' ); 
+			$content = get_sub_field( 'content_field' );
 
 			if ( $content ) { ?>
 
 				<div class="row">
 
-					<div class="single-post__article col-s-12 col-ml-8 col-ml-offset-2">			
-										
-						<?php echo $content; ?>		
+					<div class="single-post__article col-s-12 col-ml-8 col-ml-offset-2">
+
+						<?php echo $content; ?>
 
 					</div>
 
@@ -45,9 +45,9 @@ if( have_rows('single_blocks') ):
 			} ; // End if $content
 
 
-		elseif( get_row_layout() == 'blockquote' ): 
+		elseif( get_row_layout() == 'blockquote' ):
 
-			$blockquote = get_sub_field( 'blockquote_field' ); 
+			$blockquote = get_sub_field( 'blockquote_field' );
 
 			if ( $blockquote ) { ?>
 
@@ -65,10 +65,10 @@ if( have_rows('single_blocks') ):
 			} ; // End if $content
 
 
-		elseif( get_row_layout() == 'two_images' ): 
+		elseif( get_row_layout() == 'two_images' ):
 
-			$largeimage = get_sub_field( 'large_image_field' ); 
-			$smallimage = get_sub_field( 'small_image_field' ); 
+			$largeimage = get_sub_field( 'large_image_field' );
+			$smallimage = get_sub_field( 'small_image_field' );
 
 			$largeleft = get_sub_field('image_placement') == "large_image_left";
 			$largeright = get_sub_field('image_placement') == "large_image_right";
@@ -85,13 +85,13 @@ if( have_rows('single_blocks') ):
 
 						<div class="two-pictures-one col-s-12 col-ml-8">
 
-							<img src="<?php echo $largeimage['url']; ?>" class="two-pictures__image" alt="<?php echo $largeimage['alt']; ?>" />
+							<?php echo wp_get_attachment_image( $largeimage['ID'], 'fullsize', false, array( 'class' => 'two-pictures__image' ) ); ?>
 
 						</div>
 
 						<div class="two-pictures-two col-s-12 col-ml-4">
 
-							<img src="<?php echo $smallimage['url']; ?>" class="two-pictures__image" alt="<?php echo $smallimage['alt']; ?>" />
+							<?php echo wp_get_attachment_image( $smallimage['ID'], 'fullsize', false, array( 'class' => 'two-pictures__image' ) ); ?>
 
 						</div>
 
@@ -110,14 +110,14 @@ if( have_rows('single_blocks') ):
 					<div class="two-pictures">
 
 						<div class="two-pictures-one col-s-12 col-ml-8">
-							
-							<img src="<?php echo $smallimage['url']; ?>" class="two-pictures__image" alt="<?php echo $smallimage['alt']; ?>" />
+
+							<?php echo wp_get_attachment_image( $smallimage['ID'], 'fullsize', false, array( 'class' => 'two-pictures__image' ) ); ?>
 
 						</div>
 
 						<div class="two-pictures-two col-s-12 col-ml-4">
 
-							<img src="<?php echo $largeimage['url']; ?>" class="two-pictures__image" alt="<?php echo $largeimage['alt']; ?>" />
+							<?php echo wp_get_attachment_image( $largeimage['ID'], 'fullsize', false, array( 'class' => 'two-pictures__image' ) ); ?>
 
 						</div>
 

--- a/wp-content/themes/amavi2017/partials/featured-article.php
+++ b/wp-content/themes/amavi2017/partials/featured-article.php
@@ -2,20 +2,35 @@
 
 	<div class="col-s-12">
 
-		<div class="featured-article__image" style="background-image:url('<?php echo wp_get_attachment_url( get_post_thumbnail_id() );?>');">
+		<style>
+			@media screen and (max-width: 1023px) {
+				.featured-article__image--<?php echo get_post_thumbnail_id(); ?> {
+					background-image:url('<?php echo wp_get_attachment_image_url( get_post_thumbnail_id(), 'large' ); ?>');
+				}
+			}
+			@media screen and (min-width: 1024px) {
+				.featured-article__image--<?php echo get_post_thumbnail_id(); ?> {
+					background-image:url('<?php echo wp_get_attachment_image_url( get_post_thumbnail_id(), 'fullsize' ); ?>');
+
+					;
+				}
+			}
+		</style>
+
+		<div class="featured-article__image  featured-article__image--<?php echo get_post_thumbnail_id(); ?>">
 
 			<div class="featured-article__teaser row wrapper">
 
 				<div class="col-pm-offset-1 col-m-offset-2 col-s-12 col-pm-10 col-m-8 featured-article__teaser-body">
 
 					<div class="meta">
-					
+
 						<div class="meta__date">
 
-							<?php echo get_the_date(); ?> / 
-								
+							<?php echo get_the_date(); ?> /
+
 						</div>
-						
+
 						<div class="meta__category">
 
 							<?php the_category(', '); ?>

--- a/wp-content/themes/amavi2017/partials/featured-hero.php
+++ b/wp-content/themes/amavi2017/partials/featured-hero.php
@@ -14,9 +14,23 @@ setup_postdata( $post );
 		<div class="featured-hero__thumbnail-wrap">
 
 			<?php $img_id = get_post_thumbnail_id(get_the_ID()); ?>
-			<?php $alt_text = get_post_meta($img_id , '_wp_attachment_image_alt', true); ?>
 
-			<a href="<?php the_permalink(); ?>" aria-label="Read article"><div class="featured-hero__thumbnail-image" style="background-image:url('<?php echo wp_get_attachment_url( $img_id );?>');" alt="<?php echo $alt_text; ?>"></div></a>
+			<style>
+				@media screen and (max-width: 1023px) {
+					.featured-hero__thumbnail-image--<?php echo $img_id; ?> {
+						background-image:url('<?php echo wp_get_attachment_image_url( $img_id, 'large' ); ?>');
+					}
+				}
+				@media screen and (min-width: 1024px) {
+					.featured-hero__thumbnail-image--<?php echo $img_id; ?> {
+						background-image:url('<?php echo wp_get_attachment_image_url( $img_id, 'fullsize' ); ?>');
+
+						;
+					}
+				}
+			</style>
+
+			<a href="<?php the_permalink(); ?>" aria-label="Read article"><div class="featured-hero__thumbnail-image  featured-hero__thumbnail-image--<?php echo $img_id; ?>"></div></a>
 		</div>
 	</div>
 

--- a/wp-content/themes/amavi2017/single.php
+++ b/wp-content/themes/amavi2017/single.php
@@ -8,7 +8,20 @@
 
 		<!--<?php $alt_text = get_post_meta($img_id , '_wp_attachment_image_alt', true); ?>-->
 
-		<div class="single-post__hero-image col-s-12" style="background-image:url('<?php echo wp_get_attachment_url($img_id );?>'")></div>
+		<style>
+			@media screen and (max-width: 1023px) {
+				.single-post__hero-image {
+					background-image:url('<?php echo wp_get_attachment_image_url( $img_id, 'large' ); ?>');
+				}
+			}
+			@media screen and (min-width: 1024px) {
+				.single-post__hero-image {
+					background-image:url('<?php echo wp_get_attachment_image_url( $img_id, 'fullsize' ); ?>');
+				}
+			}
+		</style>
+
+		<div class="single-post__hero-image col-s-12"></div>
 
 	</div>
 


### PR DESCRIPTION
I have changed a couple of things, so hopefully you can see what I've done! 

The background images on heroes/features have been moved out into a <style> tag with two media queries that will load a smaller image on mobile than it does on larger screens. I've added another class to some of the partials so that it'll output the class with the image ID appended. This means I can directly target those elements to get the right background image in, even if they appear more than once on a page :D

Basic images are now just using the standard WP image functions, so they're outputting any alt text and also all the srcset things. They shouldn't display weirdly now that the height has been set to auto, so hopefully it all works nicely!